### PR TITLE
chore: open formula bump as a pull request

### DIFF
--- a/.github/workflows/publish-npm.yml
+++ b/.github/workflows/publish-npm.yml
@@ -34,10 +34,12 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: write
+      pull-requests: write
 
     steps:
       # The formula tracks the published tarball, so it can only be updated
-      # after the publish job succeeds. Commits land on main, not the tag.
+      # after the publish job succeeds. main requires a pull request, so the
+      # bump goes through one rather than pushing to the branch directly.
       - name: Checkout main
         uses: actions/checkout@v4
         with:
@@ -85,26 +87,39 @@ jobs:
           rm -f package.tgz
           git diff -- Formula/tardis-ai.rb
 
-      - name: Commit and push
+      - name: Open and merge pull request
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
+          version="${{ steps.version.outputs.version }}"
+
           if git diff --quiet -- Formula/tardis-ai.rb; then
-            echo "Formula already points at v${{ steps.version.outputs.version }} — nothing to commit"
+            echo "Formula already points at v${version} — nothing to commit"
             exit 0
           fi
 
+          branch="chore/formula-v${version}"
           git config user.name "github-actions[bot]"
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git checkout -b "$branch"
           git add Formula/tardis-ai.rb
-          git commit -m "chore: bump homebrew formula to v${{ steps.version.outputs.version }}"
+          git commit -m "chore: bump homebrew formula to v${version}"
+          git push --force-with-lease origin "$branch"
 
-          # main may have moved while the release ran.
-          for attempt in $(seq 1 3); do
-            if git push origin HEAD:main; then
+          gh pr create \
+            --base main \
+            --head "$branch" \
+            --title "chore: bump homebrew formula to v${version}" \
+            --body "Points the Homebrew formula at the v${version} tarball published by this release run."
+
+          # Mergeability can take a moment to compute on a fresh PR.
+          for attempt in $(seq 1 5); do
+            if gh pr merge "$branch" --squash --delete-branch; then
               exit 0
             fi
-            echo "Push rejected (attempt $attempt) — rebasing on main"
-            git pull --rebase origin main
+            echo "Merge not ready (attempt $attempt) — retrying in 5s"
+            sleep 5
           done
 
-          echo "::error::Could not push the formula bump to main"
+          echo "::error::Formula PR for v${version} was opened but could not be merged — merge it manually"
           exit 1


### PR DESCRIPTION
`main` now requires a pull request, so the `bump-formula` job can no longer push the Homebrew formula commit directly — it would be rejected on every release.

This reworks the final step to push a `chore/formula-vX.Y.Z` branch, open a PR, and squash-merge it with the `GITHUB_TOKEN`. Repository rules are satisfied because the change arrives as a PR; no approval is needed since the ruleset requires zero.

If the merge can't complete, the job fails loudly and leaves the PR open for a manual merge rather than silently skipping the bump.

Adds `pull-requests: write` to the job's permissions.