### PR TITLE
feat: add `delete` alias for the `remove` command

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,6 +113,7 @@ tardis-ai install <skill-name>            # Install a skill (defaults to Claude)
 tardis-ai install <skill-name> --ai=opencode  # Install for a specific AI
 tardis-ai update [skill-name] [--ai=...]  # Refresh installed skills in place
 tardis-ai remove <skill-name> [--ai=...]  # Remove an installed skill
+tardis-ai delete <skill-name> [--ai=...]  # Alias for remove
 ```
 
 Use `--ai=<name>` to choose where skills land. Omit it and they go to

--- a/bin/cli.js
+++ b/bin/cli.js
@@ -167,9 +167,9 @@ function isNewer(a, b) {
   return false
 }
 
-function remove(skill) {
+function remove(skill, invokedAs = 'remove') {
   if (!skill) {
-    console.error('Usage: tardis-ai remove <skill-name> [--ai=<name>]')
+    console.error(`Usage: tardis-ai ${invokedAs} <skill-name> [--ai=<name>]`)
     process.exit(1)
   }
   const dest = resolveDest()
@@ -208,6 +208,7 @@ function help() {
   console.log('  install [skill]   Install a skill (omit or use "all" to install all)')
   console.log('  update [skill]    Refresh installed skills (omit or use "all" for every one)')
   console.log('  remove <skill>    Remove an installed skill')
+  console.log('  delete <skill>    Alias for remove')
   console.log('  version           Print the installed tardis-ai version')
   console.log('')
   console.log('Options:')
@@ -255,7 +256,8 @@ switch (command) {
   case 'list':    list();          break
   case 'install': install(skillName); break
   case 'update':  update(skillName);  break
-  case 'remove':  remove(skillName);  break
+  case 'remove':
+  case 'delete':  remove(skillName, command); break
   case 'sexy':    tardis();        break
   case 'version':
   case '--version':


### PR DESCRIPTION
Closes #8

## What

`tardis-ai delete <skill>` now does exactly what `tardis-ai remove <skill>`
does. Previously `delete` fell through the switch to the default `help()`
branch, so the user got the usage screen with no hint that their command was
unrecognized.

## How

- `bin/cli.js` — `case 'delete'` falls through to `case 'remove'`, and the
  invoked command name is threaded into `remove()` so the missing-argument
  usage error names what the user actually typed.
- `tardis-ai help` lists `delete <skill>  Alias for remove`.
- README documents it in the command block next to `remove`.

No change to `remove`'s behavior, and no new dependencies.

## Verification

Ran against a scratch project directory:

| Command | Result |
| --- | --- |
| `delete commit` (installed) | `Removed "commit" from .claude/skills/commit (claude)` |
| `delete commit` (not installed) | error, exit 1 |
| `delete` (no arg) | `Usage: tardis-ai delete <skill-name> [--ai=<name>]`, exit 1 |
| `remove` (no arg) | `Usage: tardis-ai remove <skill-name> [--ai=<name>]`, exit 1 |
| `delete commit --ai=opencode` | `Removed "commit" from .opencode/skill/commit (opencode)` |
| `help` | new line renders in the command list |

## Notes

Two larger readings of "delete a skill" were considered and left out on
purpose: deleting a skill's source from this repo's `skills/` directory, and a
bulk `delete all`. Both are separate features if we ever want them.