### PR TITLE
ci: run the test suite on push and pull requests

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,35 @@
+name: Test
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+    branches:
+      - main
+  workflow_dispatch:
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+
+    strategy:
+      fail-fast: false
+      # The suite uses node:test, so it needs Node 18+ even though the
+      # published CLI still supports Node 14+. Covering the range keeps the
+      # README's "Node 18+" claim honest.
+      matrix:
+        node-version: [18, 20, 22]
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: ${{ matrix.node-version }}
+
+      # No install step: the package has no dependencies, runtime or dev.
+      - name: Run tests
+        run: npm test


### PR DESCRIPTION
Closes #11

Stacked on #12 — base is `test/cli-spec`, not `main`. The workflow runs
`npm test`, which does not exist on `main` yet. Merge #9 -> #12 -> this and each
retargets cleanly.

## What

`.github/workflows/test.yml` runs `npm test` on pushes to `main`, on pull
requests targeting `main`, and on manual dispatch.

```yaml
strategy:
  fail-fast: false
  matrix:
    node-version: [18, 20, 22]
```

Three jobs, no install step — the package has no dependencies, runtime or dev,
so checkout and setup-node is the whole preamble.

## Why the matrix

The suite uses `node:test`, so it needs Node 18+, while the published CLI still
supports Node 14+. Running 18/20/22 keeps the README's "Node 18+" claim honest
rather than assumed. `fail-fast: false` so one bad version does not mask the
others.

## Verified

- YAML parses; triggers, matrix, and steps resolve as intended
- `npm test` green locally (41 tests, 8 suites)

## Deliberately out of scope

Gating the release on a green suite. Today `update-github-version.yml` fires on
every push to `main` and chains into `publish-npm.yml`, so a red suite still
publishes. Closing that gap means adding a `needs:` edge into the release
workflow, which is worth doing deliberately and on its own rather than riding
along here. Happy to open a third issue for it.