### PR TITLE
ci: run the test suite on push and pull requests

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,35 @@
+name: Test
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+    branches:
+      - main
+  workflow_dispatch:
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+
+    strategy:
+      fail-fast: false
+      # The suite uses node:test, so it needs Node 18+ even though the
+      # published CLI still supports Node 14+. Covering the range keeps the
+      # README's "Node 18+" claim honest.
+      matrix:
+        node-version: [18, 20, 22]
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: ${{ matrix.node-version }}
+
+      # No install step: the package has no dependencies, runtime or dev.
+      - name: Run tests
+        run: npm test


### PR DESCRIPTION
Closes #11

Branched off `main`. Single file, no other changes.

## What

`.github/workflows/test.yml` runs `npm test` on pushes to `main`, on pull
requests targeting `main`, and on manual dispatch.

```yaml
strategy:
  fail-fast: false
  matrix:
    node-version: [18, 20, 22]
```

Three jobs, no install step — the package has no dependencies, runtime or dev,
so checkout plus setup-node is the whole preamble.

## Why the matrix

The suite uses `node:test`, so it needs Node 18+, while the published CLI still
supports Node 14+. Running 18/20/22 keeps the README's "Node 18+" claim honest
rather than assumed. `fail-fast: false` so one bad version does not mask the
others.

## Merge order

**This will fail CI until #14 merges** — `npm test` does not exist on `main`
yet, so the run errors with `Missing script: test`. That is expected and is not
a defect in this workflow. Merge #14 first, or merge this and accept one red run
that goes green the moment the spec lands.

I kept it as its own branch off `main` rather than stacking it on #14, as
requested.

## Deliberately out of scope

Gating the release on a green suite. Today `update-github-version.yml` fires on
every push to `main` and chains into `publish-npm.yml`, so a red suite can still
publish — see #6 and #7, which circle the same area. Closing that gap means
adding a `needs:` edge into the release workflow, worth doing on its own.