### PR TITLE
docs: add pull request template

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,21 @@
+## Summary
+
+<!-- What changes and why. One or two sentences is usually enough. -->
+
+Closes #
+
+## Steps to Test
+
+<!-- How a reviewer verifies this locally. Include the commands. -->
+
+1.
+2.
+3.
+
+## Demo
+
+<!-- Terminal output, screenshot, or a short recording. -->
+
+```console
+
+```


### PR DESCRIPTION
## Summary

Adds `.github/pull_request_template.md` so every new PR pre-fills with Summary,
Steps to Test, and Demo. This description is written in that shape as a worked
example.

Placed at the default path rather than `.github/PULL_REQUEST_TEMPLATE/feature.md`
because GitHub auto-applies exactly one template, and only from the default
path — named templates need a `?template=` query parameter and are ignored by
`gh pr create`. Bug and chore variants can be added to the directory later
without disturbing this one.

Closes #16

## Steps to Test

1. Check out the branch and confirm the file is where GitHub looks for it:

   ```bash
   git checkout docs/pr-template
   ls .github/pull_request_template.md
   ```

2. Open a new PR against this branch from any scratch branch, via the GitHub UI:

   ```
   https://github.com/janvmusic/ai-tardis-skills/compare/docs/pr-template...main
   ```

3. Confirm the description box pre-fills with the three headings, and that the
   `<!-- -->` hints are invisible in the rendered preview.

## Demo

```console
$ cat .github/pull_request_template.md
## Summary

<!-- What changes and why. One or two sentences is usually enough. -->

Closes #

## Steps to Test

<!-- How a reviewer verifies this locally. Include the commands. -->

1.
2.
3.

## Demo

<!-- Terminal output, screenshot, or a short recording. -->
```

The comment hints guide the author in the edit box and disappear from the
posted body — GitHub renders HTML comments as nothing.