### PR TITLE
test: cover the delete alias in the cli spec

### DIFF
--- a/test/cli.test.js
+++ b/test/cli.test.js
@@ -197,6 +197,39 @@ describe('remove', () => {
   })
 })
 
+describe('delete (alias for remove)', () => {
+  it('deletes an installed skill', () => {
+    run('install', 'commit')
+    const { status, stdout } = run('delete', 'commit')
+
+    assert.equal(status, 0)
+    assert.match(stdout, /Removed "commit" from \.claude\/skills\/commit \(claude\)/)
+    assert.ok(!installed('commit'))
+  })
+
+  it('honours --ai', () => {
+    run('install', 'commit', '--ai=agents')
+    run('delete', 'commit', '--ai=agents')
+
+    assert.ok(!installed('commit', path.join('.agents', 'skills')))
+  })
+
+  it('fails when the skill is not installed', () => {
+    const { status, stderr } = run('delete', 'commit')
+
+    assert.equal(status, 1)
+    assert.match(stderr, /Skill "commit" is not installed for claude\./)
+  })
+
+  it('names the typed command in the usage error, not "remove"', () => {
+    const { status, stderr } = run('delete')
+
+    assert.equal(status, 1)
+    assert.match(stderr, /Usage: tardis-ai delete <skill-name> \[--ai=<name>\]/)
+    assert.doesNotMatch(stderr, /tardis-ai remove/)
+  })
+})
+
 describe('update', () => {
   it('refreshes an installed skill', () => {
     run('install', 'commit')
@@ -290,9 +323,15 @@ describe('help', () => {
     const { status, stdout } = run('help')
 
     assert.equal(status, 0)
-    for (const command of ['list', 'install', 'update', 'remove', 'version']) {
+    for (const command of ['list', 'install', 'update', 'remove', 'delete', 'version']) {
       assert.match(stdout, new RegExp(`^ {2}${command}\\b`, 'm'))
     }
+  })
+
+  it('documents delete as an alias for remove', () => {
+    const { stdout } = run('help')
+
+    assert.match(stdout, /^ {2}delete <skill> {4}Alias for remove$/m)
   })
 
   it('documents every --ai target', () => {


### PR DESCRIPTION
## Summary

Restores the five assertions covering the `delete` alias that were cut from #14
when it was retargeted to `main`. At that point `main` had no alias and they
failed; #9 and #14 have both landed since, so they pass now.

Suite goes from 36 tests / 7 suites to **41 tests / 8 suites**. No production
code changes — `test/cli.test.js` only.

Closes #19

## Steps to Test

1. Confirm the alias currently has zero coverage on `main`:

   ```bash
   git checkout main
   grep -c "describe('delete" test/cli.test.js   # -> 0
   ```

2. Check out this branch and run the suite:

   ```bash
   git checkout test/delete-alias-spec
   npm test
   ```

3. Confirm the tests actually guard the feature rather than just passing —
   delete the `case 'delete':` line from `bin/cli.js` and re-run. Four tests
   should fail. Restore it and they go green.

## Demo

```console
$ npm test
ℹ tests 41
ℹ suites 8
ℹ pass 41
ℹ fail 0

# with `case 'delete':` removed from bin/cli.js:
$ npm test
ℹ tests 41
ℹ pass 37
ℹ fail 4
```

The four failures are exactly the alias tests, which is the point — without the
alias in `bin/cli.js` they fail, so they are guarding the feature and not
passing incidentally.