### PR TITLE
docs: document pr and testing conventions in claude.md

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -44,7 +44,28 @@ description: { one-line description used for triggering and discovery }
 - Follow conventional commit format: `{type}({ticket}): {description}`
 - Valid types: `feat`, `fix`, `refactor`, `docs`, `style`, `test`, `chore`, `perf`
 - Keep commit messages under 72 characters, single-line, imperative mood, lowercase
+  (a convention for humans — CI does not measure length)
 - Stage files individually — never use `git add -A`
+
+### Pull Requests
+
+- PR titles follow the same conventional commit format as commits, and CI
+  validates the type and subject. Length is not checked.
+- The title matters beyond review: it becomes the squashed commit message on
+  `main` and feeds `--generate-notes` in the release workflow, so it lands in
+  published release notes verbatim.
+- `.github/pull_request_template.md` pre-fills every PR with Summary (including
+  a `Closes #` line), Steps to Test, and Demo. Fill in all three.
+
+### Testing
+
+- The CLI has a spec at `test/cli.test.js`. Run it with `npm test`.
+- It uses Node's built-in `node:test` runner and has no dependencies. Keep it
+  that way — the package ships with none, runtime or dev.
+- Tests spawn the real `bin/cli.js` against a temp directory, since the CLI runs
+  its `switch` at module load. Assert on stdout, stderr, exit code, and the
+  files left on disk.
+- Any change to `bin/cli.js` needs matching coverage in the spec.
 
 ## Adding a New Skill
 


### PR DESCRIPTION
## Summary

`CLAUDE.md` has gone stale — the repo grew a test suite, a PR template, and a CI
workflow, none of which it mentions. It also implied the 72-character rule was
hard, which we decided not to enforce (see #18).

Three changes:

- **Git & Commits** — the 72-character limit is marked as a human convention
  that CI does not measure, closing out the open question in #18.
- **Pull Requests** (new) — PR titles follow conventional commits and are
  CI-validated on type and subject, not length. Notes that the title becomes the
  squashed commit on `main` and feeds `--generate-notes`, so it reaches
  published release notes verbatim. Points at the PR template.
- **Testing** (new) — `npm test`, the zero-dependency `node:test` constraint, why
  the spec spawns the real binary, and that `bin/cli.js` changes need matching
  coverage.

## Steps to Test

1. Read the diff — documentation only, no code:

   ```bash
   git diff main...docs/claude-md-conventions
   ```

2. Confirm the claims are accurate against the repo:

   ```bash
   npm test                              # the spec exists and passes
   node -p "require('./package.json').devDependencies"   # undefined
   ls .github/pull_request_template.md   # from #17
   ```

## Demo

```console
$ npm test
ℹ tests 41
ℹ suites 8
ℹ pass 41
ℹ fail 0

$ node -p "require('./package.json').devDependencies"
undefined
```

## Note on merge order

Two statements describe work still in flight:

- the PR template line depends on **#17**
- "CI validates the type and subject" depends on **#18**, which is an issue with
  no PR yet

Merging this first makes CLAUDE.md briefly describe the intended state rather
than the current one. Merge after #17 if that bothers you; the #18 line is a
statement of the convention either way, and the workflow enforcing it can follow.