### PR TITLE
ci: validate pull request titles

### DIFF
--- a/.github/workflows/pr-title.yml
+++ b/.github/workflows/pr-title.yml
@@ -1,0 +1,43 @@
+name: PR Title
+
+# The PR title is not just review furniture: with squash merging it becomes the
+# commit message on main verbatim, and `gh release create --generate-notes` in
+# update-github-version.yml pulls it into the published release notes.
+on:
+  pull_request_target:
+    types: [opened, edited, synchronize, reopened]
+
+permissions:
+  pull-requests: read
+
+jobs:
+  title:
+    runs-on: ubuntu-latest
+
+    steps:
+      # Reads the title from the event payload — never checks out branch code,
+      # so pull_request_target carries none of its usual risk here. Using it
+      # rather than pull_request means fork PRs are validated too.
+      - uses: amannn/action-semantic-pull-request@v5
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          # Kept in step with the type list in CLAUDE.md.
+          types: |
+            feat
+            fix
+            refactor
+            docs
+            style
+            test
+            chore
+            perf
+            ci
+          # CLAUDE.md allows a {ticket} scope but this repo rarely uses one.
+          requireScope: false
+          # Lowercase first letter, no trailing period. Length is deliberately
+          # unchecked — CLAUDE.md's 72-character rule is a human convention.
+          subjectPattern: ^[a-z].*[^.]$
+          subjectPatternError: |
+            The subject "{subject}" is invalid for the title "{title}".
+            It must start with a lowercase letter and must not end with a period.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -42,7 +42,7 @@ description: { one-line description used for triggering and discovery }
 ### Git & Commits
 
 - Follow conventional commit format: `{type}({ticket}): {description}`
-- Valid types: `feat`, `fix`, `refactor`, `docs`, `style`, `test`, `chore`, `perf`
+- Valid types: `feat`, `fix`, `refactor`, `docs`, `style`, `test`, `chore`, `perf`, `ci`
 - Keep commit messages under 72 characters, single-line, imperative mood, lowercase
   (a convention for humans — CI does not measure length)
 - Stage files individually — never use `git add -A`


### PR DESCRIPTION
## Summary

Adds `.github/workflows/pr-title.yml`, failing the check when a PR title does
not parse as a conventional commit. Uses `amannn/action-semantic-pull-request@v5`.

This matters more now that squash merging is the default: the PR title becomes
the commit message on `main` verbatim, and `gh release create --generate-notes`
in `update-github-version.yml` pulls it into published release notes.

**Also adds `ci` to the valid type list in CLAUDE.md.** Building this surfaced
that `ci` was never in that list, even though `main`'s own history uses it —
#15 merged as `ci: run the test suite on push and pull requests`. Enforcing the
documented list as-is would have rejected a type the repo already relies on, and
this PR's own title too. Adding it is the smaller correction; the alternative is
renaming those to `chore:`, which I did not want to decide unilaterally.

Per the decisions recorded on #18: type and subject are validated, **length is
not** — the 72-character rule stays a human convention.

Closes #18

## Steps to Test

1. Confirm the workflow's type list and CLAUDE.md agree:

   ```bash
   grep '^- Valid types:' CLAUDE.md | grep -oE '`[a-z]+`' | tr -d '`' | sort > /tmp/a
   ruby -ryaml -e 'puts YAML.load_file(".github/workflows/pr-title.yml")["jobs"]["title"]["steps"][0]["with"]["types"].split' | sort > /tmp/b
   diff /tmp/a /tmp/b   # no output
   ```

2. Confirm no existing merged PR title would be rejected — every one of #9, #14,
   #15, #17, #20, #21 passes both the type list and `^[a-z].*[^.]$`.

3. After merge, edit any open PR's title to something invalid (`Fixed stuff`)
   and confirm the check fails, then fix it and confirm it clears without a push
   — the `edited` trigger handles that.

## Demo

```console
$ diff /tmp/a /tmp/b && echo "MATCH: $(tr '\n' ' ' < /tmp/a)"
MATCH: chore ci docs feat fix perf refactor style test

$ # every merged PR title checked against type list + subject pattern
  ok  #21  docs: document pr and testing conventions in claude.md
  ok  #20  test: cover the delete alias in the cli spec
  ok  #17  docs: add pull request template
  ok  #15  ci: run the test suite on push and pull requests
  ok  #14  test: add spec for \`bin/cli.js\`
  ok  #9   feat: add \`delete\` alias for the \`remove\` command
```

## Notes

**This PR cannot validate itself.** `pull_request_target` runs the workflow from
the *base* branch, so the check only starts working once this is on `main`. Its
title was checked by hand against the same rules.

**Why `pull_request_target`.** The step reads the title from the event payload
and never checks out branch code, so the usual risk of that trigger does not
apply. It buys validation on fork PRs.

**Action pinned to `v5`, not a SHA.** Tighter supply-chain hygiene would pin the
commit SHA. Happy to do that as a follow-up if you want it.