### PR TITLE
ci: rename workflow checks to unit tests and validate pr title

### DIFF
--- a/.github/workflows/pr-title.yml
+++ b/.github/workflows/pr-title.yml
@@ -1,4 +1,4 @@
-name: PR Title
+name: Validate PR title
 
 # The PR title is not just review furniture: with squash merging it becomes the
 # commit message on main verbatim, and `gh release create --generate-notes` in
@@ -12,6 +12,7 @@ permissions:
 
 jobs:
   title:
+    name: Validate PR title
     runs-on: ubuntu-latest
 
     steps:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,4 +1,4 @@
-name: Test
+name: Unit Tests
 
 on:
   push:
@@ -11,6 +11,7 @@ on:
 
 jobs:
   test:
+    name: Unit Tests
     runs-on: ubuntu-latest
 
     strategy:


### PR DESCRIPTION
## Summary

Renames both CI workflows and their jobs so the checks that appear on a PR read
as `Unit Tests` and `Validate PR title` instead of `Test` / `test` and
`PR Title` / `title`. The job-level `name:` is the part that matters — a branch
ruleset binds its required status checks to the job display name, so these are
the strings that go in **Require status checks to pass**.

Nothing else in the repo referenced the old names, so no other file changes.

Two wrinkles a reviewer should expect on this PR's own checks:

- **`Unit Tests` still reports per matrix leg** (`Unit Tests (18)`, `(20)`,
  `(22)`) because `main` still has the Node matrix. #25 removes it; once that
  merges the check collapses to a single `Unit Tests`. Wire the ruleset up
  after #25, or you will be pinning check names that are about to change.
- **The PR-title check still reports as `title` here.** `pr-title.yml` runs on
  `pull_request_target`, which always uses the workflow file from the base
  branch — so this PR is validated by `main`'s copy, not its own. The new name
  appears on the first PR opened after this merges.

Closes #26

## Steps to Test

1. Open the Checks tab on this PR: the test checks now read `Unit Tests (18)` /
   `(20)` / `(22)` rather than `test (18)` / … . The PR-title check still reads
   `title` for the reason above.
2. After merge, open any PR and confirm the check reads `Validate PR title`.
3. Workflow logic is untouched — `npm test` passes locally and in CI.

## Demo

```console
$ gh pr checks 27
Unit Tests (18)   pass  13s
Unit Tests (20)   pass  13s
Unit Tests (22)   pass  10s
title             pass   3s
```
