### PR TITLE
chore: release v1.7.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ai-tardis-skills",
-  "version": "1.6.1",
+  "version": "1.7.0",
   "description": "CLI to manage AI skills for Claude Code",
   "bin": {
     "tardis-ai": "bin/cli.js"


### PR DESCRIPTION
## Summary

Bumps `package.json` to 1.7.0. Minor rather than patch because `delete` landed
as a new command since v1.6.1 (#8); everything else on `main` is docs, CI and
`personal/`, none of which is in the published tarball.

Merging this triggers "Update Github Version", which cuts the tag and release,
which in turn triggers "Publish to npm" through `workflow_run`.

Heads up: the formula-bump job pushes straight to `main`, and ruleset 21052110
requires status checks there with no bypass actors, so that push will be
rejected. `Formula/tardis-ai.rb` will need a manual bump to the 1.7.0 tarball
after npm publishes.

## Steps to Test

1. `node -p "require('./package.json').version"` prints `1.7.0`
2. `npm test` passes, 41 tests
3. `npm pack --dry-run` still lists only `bin/`, `skills/`, `README.md`, `package.json`
4. After merge, confirm the v1.7.0 release and the npm publish run

## Demo

```console
$ node -p "require('./package.json').version"
1.7.0

$ npm test 2>&1 | tail -4
ℹ pass 41
ℹ fail 0
```
