### PR TITLE
chore: bump homebrew formula to v1.7.0

### DIFF
--- a/Formula/tardis-ai.rb
+++ b/Formula/tardis-ai.rb
@@ -1,8 +1,8 @@
 class TardisAi < Formula
   desc "CLI to manage AI skills for Claude Code, OpenCode, and other agents"
   homepage "https://github.com/janvmusic/ai-tardis-skills"
-  url "https://registry.npmjs.org/ai-tardis-skills/-/ai-tardis-skills-1.6.1.tgz"
-  sha256 "08aa22da8b171485a719a52cb50f68fd18eaafcd881f3596593f7297b12523c7"
+  url "https://registry.npmjs.org/ai-tardis-skills/-/ai-tardis-skills-1.7.0.tgz"
+  sha256 "d17df089287a508c4d9f24fe67899710b42fea19c663f9d72d6238c7ecb62c2b"
   license "MIT"
 
   depends_on "node"


### PR DESCRIPTION
## Summary

Points the formula at the 1.7.0 tarball. The `bump-formula` job in "Publish to
npm" computed the same change but could not push it: ruleset 21052110 on `main`
requires two status checks with no bypass actors, so the direct push was
rejected with `GH013`. npm published fine, only the formula was left behind.

Closes nothing; the underlying automation gap needs its own issue.

## Steps to Test

1. `brew tap janvmusic/tardis https://github.com/janvmusic/ai-tardis-skills`
2. `brew upgrade tardis-ai`
3. `tardis-ai version` prints `tardis-ai v1.7.0`
4. `tardis-ai delete --help` shows the alias shipped in this release

## Demo

```console
$ curl -sL https://registry.npmjs.org/ai-tardis-skills/-/ai-tardis-skills-1.7.0.tgz | shasum -a 256
d17df089287a508c4d9f24fe67899710b42fea19c663f9d72d6238c7ecb62c2b

$ npm view ai-tardis-skills version
1.7.0
```
